### PR TITLE
add CddInterface & NConvex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - REPO_URL=https://github.com/gap-packages/biogap.git
     - REPO_URL=https://github.com/gap-packages/BlissInterface.git
     - REPO_URL=https://github.com/gap-packages/CaratInterface.git
+    - REPO_URL=https://github.com/homalg-project/CddInterface.git
     - REPO_URL=https://github.com/gap-packages/Char0Gauss.git
     - REPO_URL=https://github.com/gap-packages/circle.git
     - REPO_URL=https://github.com/gap-packages/cohomolo.git
@@ -96,6 +97,7 @@ env:
     - REPO_URL=https://github.com/gap-packages/modisom.git
     - REPO_URL=https://github.com/le-on/ModularGroup.git
     - REPO_URL=https://github.com/gap-packages/NautyTracesInterface.git
+    - REPO_URL=https://github.com/homalg-project/NConvex.git
     - REPO_URL=https://github.com/gap-packages/nilmat.git
     - REPO_URL=https://github.com/pjastr/NoCK.git
     - REPO_URL=https://github.com/gap-packages/NormalizInterface.git


### PR DESCRIPTION
In this PR I did not touch ci.sh just to make sure that prerequisites.sh is enough as for the case of semi-groups package.